### PR TITLE
Added InProgress build status, worked around subtle polling issue

### DIFF
--- a/Tfs.BuildNotifications/Tfs.BuildNotifications.Core/Extensions/BuildExtensions.cs
+++ b/Tfs.BuildNotifications/Tfs.BuildNotifications.Core/Extensions/BuildExtensions.cs
@@ -4,22 +4,31 @@ namespace Tfs.BuildNotifications.Core.Extensions
 {
     public static class BuildExtensions
     {
-        public static BuildResult ToBuildResult(this string s)
+        public static BuildResult GetBuildResult(this Build build)
         {
-            switch (s?.Trim().ToLower())
+            var buildResult = Model.BuildResult.Unknown;
+
+            switch (build?.Result?.Trim().ToLower())
             {
                 case "succeeded":
-                    return BuildResult.Succeeded;
+                    buildResult = BuildResult.Succeeded;
+                    break;
 
                 case "failed":
-                    return BuildResult.Failed;
+                    buildResult = BuildResult.Failed;
+                    break;
 
                 case "canceled":
-                    return BuildResult.Stopped;
-
-                default:
-                    return BuildResult.Unknown;
+                    buildResult = BuildResult.Stopped;
+                    break;
             }
+
+            if (buildResult == BuildResult.Unknown && build.InProgress)
+            {
+                buildResult = BuildResult.InProgress;
+            }
+
+            return buildResult;
         }
     }
 }

--- a/Tfs.BuildNotifications/Tfs.BuildNotifications.Model/BuildStatus.cs
+++ b/Tfs.BuildNotifications/Tfs.BuildNotifications.Model/BuildStatus.cs
@@ -5,6 +5,7 @@
         Unknown,
         Succeeded,
         Failed,
-        Stopped
+        Stopped,
+        InProgress
     }
 }

--- a/Tfs.BuildNotifications/Tfs.BuildNotifications.Tray/App.config
+++ b/Tfs.BuildNotifications/Tfs.BuildNotifications.Tray/App.config
@@ -6,7 +6,7 @@
   <appSettings>
     <add key="WebApp.Port" value="7100" />
     <add key="Notifications.TimerIntervalMinutes" value="1" />
-    <add key="ToolTipNotifications.Enabled" value="false" />
+    <add key="ToolTipNotifications.Enabled" value="true" />
     <add key="TextToSpeech.Enabled" value="false" />
     <add key="TrayNotifications.NonSuccessfulBuildsOnly" value="false" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />

--- a/Tfs.BuildNotifications/Tfs.BuildNotifications.Tray/Services/NotificationService.cs
+++ b/Tfs.BuildNotifications/Tfs.BuildNotifications.Tray/Services/NotificationService.cs
@@ -31,7 +31,7 @@ namespace Tfs.BuildNotifications.Tray.Services
 		{
 			if (_appConfig.NotifyNonSuccessfulBuildsOnly)
 			{
-				if (build.Result.ToBuildResult() != BuildResult.Succeeded)
+				if (build.GetBuildResult() != BuildResult.Succeeded)
 				{
 					ShowBuildStatusNotification(build);
 				}
@@ -64,7 +64,7 @@ namespace Tfs.BuildNotifications.Tray.Services
 		{
 			if (!build.InProgress)
 			{
-				var result = build.Result.ToBuildResult();
+				var result = build.GetBuildResult();
 
 				Action onClick = () => Process.Start(build.Url);
 
@@ -85,7 +85,12 @@ namespace Tfs.BuildNotifications.Tray.Services
 							BuildCompletedIcon, onClick);
 						break;
 
-					default:
+                    case BuildResult.InProgress:
+                        ShowNotification(build.DefinitionName, $"Build in progress. Requested by {build.LastRequestedBy}",
+                            BuildCompletedIcon, onClick);
+                        break;
+
+                    default:
 						ShowNotification(build.DefinitionName, "Build status unknown. Click for details.",
 							BuildStatusUnknownIcon, onClick);
 						break;

--- a/Tfs.BuildNotifications/Tfs.BuildNotifications.Web/ViewModels/HomeViewModel.cs
+++ b/Tfs.BuildNotifications/Tfs.BuildNotifications.Web/ViewModels/HomeViewModel.cs
@@ -23,7 +23,7 @@ namespace Tfs.BuildNotifications.Web.ViewModels
                 return "history-running";
             }
 
-            switch (build.Result.ToBuildResult())
+            switch (build.GetBuildResult())
             {
                 case BuildResult.Succeeded:
                     return "history-success";
@@ -85,7 +85,7 @@ namespace Tfs.BuildNotifications.Web.ViewModels
 
         public Guid LocalId { get; set; }
 
-        public BuildResult Status => Builds.FirstOrDefault()?.Result.ToBuildResult() ?? BuildResult.Unknown;
+        public BuildResult Status => Builds.FirstOrDefault()?.GetBuildResult() ?? BuildResult.Unknown;
 
         public bool RequiresAttention => Status == BuildResult.Failed || Status == BuildResult.Stopped;
 

--- a/Tfs.BuildNotifications/Tfs.BuildNotifications.Web/Views/Index.cshtml
+++ b/Tfs.BuildNotifications/Tfs.BuildNotifications.Web/Views/Index.cshtml
@@ -159,7 +159,7 @@ else
                                             <div class="build-history">
                                                 @foreach (var build in buildDefinition.Builds.Take(6))
                                                 {
-                                                    <a target="_blank" href="@build.Url" title="@("Status: " + build.Result.ToBuildResult().ToString() + ". Finished at " + (build.LastFinished == null ? "N/A" : build.LastFinished.ToString()))">
+                                                    <a target="_blank" href="@build.Url" title="@("Status: " + build.GetBuildResult().ToString() + ". Finished at " + (build.LastFinished == null ? "N/A" : build.LastFinished.ToString()))">
                                                         <span class="@Model.GetHistoryCssClassName(build)"></span>
                                                     </a>
                                                 }

--- a/Tfs.BuildNotifications/Tfs.BuildNotifications.Web/Views/Shared/_BuildSummary.cshtml
+++ b/Tfs.BuildNotifications/Tfs.BuildNotifications.Web/Views/Shared/_BuildSummary.cshtml
@@ -34,7 +34,7 @@
             <div class="build-history">
                 @foreach (var build in Model.BuildDefinition.Builds.Take(6))
                 {
-                    <a target="_blank" href="@build.Url" title="@("Status: " + build.Result.ToBuildResult().ToString() + ". Finished at " + (build.LastFinished == null ? "N/A" : build.LastFinished.ToString()))">
+                    <a target="_blank" href="@build.Url" title="@("Status: " + build.GetBuildResult().ToString() + ". Finished at " + (build.LastFinished == null ? "N/A" : build.LastFinished.ToString()))">
                         <span class="@Model.GetHistoryCssClassName(build)"></span>
                     </a>
                 }


### PR DESCRIPTION
Added an additional status of InProgress - if the build.Result is null and InProgress = true
Changed the PollingService logic so that it is only looking for either new builds or builds with a changed InProgress indicator. This removes the reliance on synchronised date/times between the local machine and the TFS build machine which was causing completed build notifications to be missed.